### PR TITLE
fix: file URI reformatting in DISLoader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+
+.gradle/
+
+working_dir/
+
+scenegraph/
+
+app/bin/
+
+app/build/
+
+app/dist/

--- a/app/src/main/java/corelyzer/io/DISLoader.java
+++ b/app/src/main/java/corelyzer/io/DISLoader.java
@@ -459,16 +459,16 @@ public class DISLoader {
 										System.out.println("[URL OK] the path is: " + relativePath);
 										System.out.println("[URL OK] the file is: " + fff);
 
-										// replace with local prefix + path
-										boolean MAC_OS_X = System.getProperty("os.name").toLowerCase().startsWith("mac os x");
-										if (MAC_OS_X) {
-
-										} else { // assume Windows only
+										// replace with local prefix + pathos.name
+										boolean WIN = System.getProperty("os.name").toLowerCase().contains("win");
+										if (WIN) { // assume Windows only
 											// "FILE://C:\DIS\Images\keke.jpg"
 											imageUrl = "file:///" + app.preferences().getProperty("dis.prefix") + sp + imageUrl.substring(10);
 
 											System.out.println("[DISLoader] !Mac's imageUrl: " + imageUrl);
-										}
+										} else {
+                                                                                    
+                                                                                }
 									} catch (MalformedURLException ex) {
 										// might be the case of
 										// "FILE://C:\DIS\Images\keke.jpg" in


### PR DESCRIPTION
Fixes corewall/corelyzer#8
Inherited problem from the time when Corelyzer was Win and Mac only: DISLoader checked for Mac OS, if positive it did nothing to the file path, if negative it changed the file path formatting for Windows, i.e. it also changed file formatting to Windows on a Linux system. After this fix, DISLoader will check for Windows OS and change the path if positive, if negative it will do nothing to the file path. Thus, it is not only a fix for Linux but should work with all POSIX systems.