### PR TITLE
fix: save preset options in trim dialogue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+
+.gradle/
+
+working_dir/
+
+scenegraph/
+
+app/bin/
+
+app/build/
+
+app/dist/

--- a/app/src/main/java/corelyzer/io/DISLoader.java
+++ b/app/src/main/java/corelyzer/io/DISLoader.java
@@ -459,16 +459,16 @@ public class DISLoader {
 										System.out.println("[URL OK] the path is: " + relativePath);
 										System.out.println("[URL OK] the file is: " + fff);
 
-										// replace with local prefix + path
-										boolean MAC_OS_X = System.getProperty("os.name").toLowerCase().startsWith("mac os x");
-										if (MAC_OS_X) {
-
-										} else { // assume Windows only
+										// replace with local prefix + pathos.name
+										boolean WIN = System.getProperty("os.name").toLowerCase().contains("win");
+										if (WIN) { // assume Windows only
 											// "FILE://C:\DIS\Images\keke.jpg"
 											imageUrl = "file:///" + app.preferences().getProperty("dis.prefix") + sp + imageUrl.substring(10);
 
 											System.out.println("[DISLoader] !Mac's imageUrl: " + imageUrl);
-										}
+										} else {
+                                                                                    
+                                                                                }
 									} catch (MalformedURLException ex) {
 										// might be the case of
 										// "FILE://C:\DIS\Images\keke.jpg" in

--- a/app/src/main/java/corelyzer/ui/TrimDialog.java
+++ b/app/src/main/java/corelyzer/ui/TrimDialog.java
@@ -85,8 +85,8 @@ public class TrimDialog extends JDialog
 		
 		affectedSectionsBox = new JComboBox<String>();
 		final DefaultComboBoxModel<String> affectedSectionsModel = new DefaultComboBoxModel<String>();
-		affectedSectionsModel.addElement("selected and deeper sections");
 		affectedSectionsModel.addElement("selected section only");
+                affectedSectionsModel.addElement("selected and deeper sections");
 		affectedSectionsBox.setModel(affectedSectionsModel);
 		
 		closeButton = new JButton("Close");
@@ -118,7 +118,7 @@ public class TrimDialog extends JDialog
 		if (trimValue != -1.0f)
 			trimField.setText(Float.toString(trimValue));
 		else
-			trimField.setText("???");
+			trimField.setText("0");
 	}
 	
 	private void updateFromToLabel()


### PR DESCRIPTION
Closes #11 
Exchanged only the two lines in the trim box drop-down menu to put "selected section only" on the top, which makes it selected by default.